### PR TITLE
Paste view bug patch.

### DIFF
--- a/igiagbin/Views/Paste/Details.cshtml
+++ b/igiagbin/Views/Paste/Details.cshtml
@@ -13,7 +13,7 @@
 			</div>
 			<label class="label">Paste content</label>
 			<div class="control">
-				<code class="textarea" placeholder="Textarea" id="PasteContents">@Model.Contents</code>
+				<code class="textarea" placeholder="Textarea" id="PasteContents" style="overflow-y: auto">@Model.Contents</code>
 			</div>
 		</div>
 		<div class="control">

--- a/igiagbin/Views/Paste/Details.cshtml
+++ b/igiagbin/Views/Paste/Details.cshtml
@@ -9,7 +9,7 @@
 		<div class="field">
 			<label class="label">Upload date</label>
 			<div class="control mb-2">
-				<code placeholder="Textarea" id="PasteContents">@Model.UploadedOn</code>
+				<code placeholder="Textarea" id="PasteContentsDate">@Model.UploadedOn</code>
 			</div>
 			<label class="label">Paste content</label>
 			<div class="control">


### PR DESCRIPTION
- Fixed text overflow bug, by introducing `style="overflow-y: auto"` property to paste contents' code field.
- Fixed content copy button's behavior by changing the id of upload date's code field to `PasteContentsDate`